### PR TITLE
Change in flask deployment commands

### DIFF
--- a/apps/flask/Dockerfile
+++ b/apps/flask/Dockerfile
@@ -14,4 +14,6 @@ EXPOSE 8080
 
 ENTRYPOINT ["/bin/ash", "/entrypoint.sh"]
 
-CMD ["python", "app.py"]
+CMD ["export", "FLASK_APP=app.py"]
+
+CMD ["flask", "run"]


### PR DESCRIPTION
These might be better commands, I'm not sure if I properly wrote them, but this will make the settings of host and port settings inside the app.py useless and rather use a default port